### PR TITLE
Update README and CLAUDE documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,9 @@
 # Lugli Language - AI Assistant Development Guide
 
+**Version:** 0.4.0
+**Status:** Stable foundation with 651 passing tests
+**Last Updated:** 2025-11-05
+
 ## 🎯 Project Objective & Language Philosophy
 
 **Lugli** is the "child of Python and Rust" - a high-performance, high-level programming language that marries **Python's simplicity and readability** with **Rust's performance and modern syntax**.
@@ -33,11 +37,11 @@ Lugli combines the best of both worlds:
 
 ## 🌊 Lugli Syntax Guide
 
-> **Note**: This guide is divided into **Current Syntax** (v0.3.2, fully implemented) and **Future Syntax** (v0.4.0+, planned features).
+> **Note**: This guide is divided into **Current Syntax** (v0.4.0, fully implemented) and **Future Syntax** (planned features).
 
 ---
 
-## ✅ Current Syntax (v0.3.2 - Fully Implemented)
+## ✅ Current Syntax (v0.4.0 - Fully Implemented)
 
 ### **Variable Declaration**
 
@@ -220,7 +224,7 @@ text.upper()     # ✅ Works
 
 ---
 
-## 🔮 Future Syntax (v0.4.0+ - Planned)
+## 🔮 Future Syntax (Planned)
 
 ### **Advanced Features** ❌ NOT YET IMPLEMENTED
 
@@ -288,7 +292,7 @@ let result = process.run("ls", ["-la"])
 
 ## 🏗️ Architecture Overview
 
-The project is organized as a **Rust workspace** with **7 professional crates** in the `crates/` directory:
+The project is organized as a **Rust workspace** with **8 professional crates** in the `crates/` directory:
 
 ### Crate Dependencies
 
@@ -296,6 +300,8 @@ The project is organized as a **Rust workspace** with **7 professional crates** 
 
 ```
 lugli (CLI) → all crates
+    ↓
+lugli-benchmarks → lugli-vm + lugli-parser + lugli-lexer (testing only)
     ↓
 lugli-vm → lugli-common + lugli-lexer + lugli-ast + lugli-parser + lugli-stdlib
     ↓
@@ -313,6 +319,7 @@ lugli-common (Foundation)
 **Key Characteristics:**
 - `lugli-common` is a foundational crate imported by all others (shared types)
 - `lugli` CLI depends directly on all crates for maximum flexibility
+- `lugli-benchmarks` provides performance regression testing
 - Each layer depends on all layers below it, not just the immediate neighbor
 - No circular dependencies (clean dependency tree)
 
@@ -364,8 +371,15 @@ lugli-common (Foundation)
 #### `lugli` (main)
 
 -   **Purpose**: CLI tool and REPL
--   **Technology**: `clap` for CLI, custom REPL with syntax highlighting
--   **Commands**: `run`, `repl`, `check`, `fmt`, `test`
+-   **Technology**: `clap` for CLI, `rustyline` for enhanced REPL with history
+-   **Commands**: `run`, `repl`, `check`, `disassemble`, `version`
+
+#### `lugli-benchmarks`
+
+-   **Purpose**: Performance benchmarking and regression testing
+-   **Technology**: `criterion` for statistical benchmarks
+-   **Features**: Lexer, parser, and VM execution benchmarks
+-   **Integration**: Workspace development tool for performance tracking
 
 ---
 
@@ -551,99 +565,6 @@ fn lexer_benchmark(c: &mut Criterion) {
 
 ---
 
-## 🔄 Syntax Implementation Guide
-
-### **Priority Implementation Order**
-
-#### Phase 2.1: Core Syntax Updates
-
-1. **Lexer Updates**:
-
-    - Add `let` and `mut` keywords
-    - Support both `#` and `//` comments
-    - Add `match` keyword for pattern matching
-    - Add f-string tokenization (`f"..."`)
-
-2. **Parser Updates**:
-
-    - Replace `create` with `let`/`mut` in variable declarations
-    - Update struct methods to use `self` instead of `this`
-    - Add pattern matching syntax parsing
-    - Support optional type hints syntax
-
-3. **Example Updates**:
-    - Convert all examples to new syntax
-    - Add new examples for modern features
-    - Update REPL prompts and error messages
-
-#### Phase 2.2: Modern Features
-
-1. **String Interpolation**: F-string support
-2. **List Comprehensions**: Python-style syntax
-3. **Pattern Matching**: Rust-inspired match expressions
-4. **Type Hints**: Optional typing for better tooling
-
-#### Phase 2.3: Standard Library
-
-1. **Pythonic APIs**: `print()`, `len()`, `str()`, `int()`
-2. **Enumerate Function**: For indexed iteration
-3. **Range Function**: For numeric iteration
-4. **Modern Collections**: Enhanced dict and list APIs
-
-### **Syntax Migration Strategy**
-
-#### Backward Compatibility
-
--   Keep `create` as alias for `let` during transition
--   Support both comment styles (`#` and `//`)
--   Maintain `println!` alongside new `print()`
--   Keep current method naming (`!` and `?`) working
-
-#### Migration Path
-
-1. **Phase 1**: Add new syntax alongside old
-2. **Phase 2**: Update all examples to new style
-3. **Phase 3**: Deprecate old syntax with warnings
-4. **Phase 4**: Remove deprecated syntax
-
-### **Testing Each Syntax Feature**
-
-For each new syntax element:
-
-1. **Lexer tests**: Tokenization correctness
-2. **Parser tests**: AST generation
-3. **Runtime tests**: Execution behavior
-4. **Example files**: Usage demonstration
-5. **Error tests**: Helpful error messages
-6. **Performance tests**: No regressions
-
-### **Example File Organization**
-
-```
-examples/
-├── syntax/
-│   ├── 01_variables.lg       # let, mut, const
-│   ├── 02_functions.lg       # fn with type hints
-│   ├── 03_structs.lg         # struct with self
-│   ├── 04_control_flow.lg    # if/elif/else, match
-│   ├── 05_collections.lg     # lists, dicts, comprehensions
-│   ├── 06_strings.lg         # f-strings, formatting
-│   ├── 07_loops.lg           # for/while/loop
-│   ├── 08_imports.lg         # import system
-│   ├── 09_comments.lg        # comment styles
-│   └── 10_types.lg           # type hints
-├── tutorials/
-│   ├── hello_world.lg        # First program
-│   ├── calculator.lg         # Basic arithmetic
-│   └── todo_list.lg          # Data structures
-└── samples/
-    ├── hangman.lg            # Game implementation
-    ├── web_server.lg         # Async example
-    └── data_analysis.lg      # List comprehensions
-```
-
----
-
 ## 🚀 Development Workflow
 
 ### Adding New Language Features
@@ -690,7 +611,10 @@ cargo test --workspace
 cargo test -p lugli-lexer
 
 # Run benchmarks
-cargo bench
+cargo bench --workspace
+
+# Run specific benchmark
+cargo bench -p lugli-benchmarks
 
 # Check for issues
 cargo clippy --workspace
@@ -820,36 +744,72 @@ cargo flamegraph --bin lugli -- run large_program.lg
 
 ---
 
-## 🔄 Development Status
+## ✅ Feature Status
 
-### ✅ v0.3.2 - Production-Safe VM
+### Fully Implemented Features (v0.4.0)
 
--   **Tests**: 385 passing, 5 ignored (390 total)
--   **VM**: Stack-based bytecode execution, panic-safe
--   **Features**: F-strings, list comprehensions, pattern matching, closures, structs
--   **Safety**: All RefCell panics fixed, bounds checks, proper error handling
-
-### ✅ Complete Features
-
--   7-crate workspace with clean architecture
--   VM-only execution (no tree-walking interpreter)
--   Pattern matching with guards
+**Core Language:**
+-   Variables, functions, structs with methods
+-   Control flow: `if/elif/else`, `while`, `for`, `loop`, `break`, `continue`
+-   Pattern matching with guards and wildcards
 -   List comprehensions with filters
 -   F-string interpolation
 -   Closures with upvalue capture
--   Struct methods and properties
--   Enhanced error messages
+-   Collections: lists and dictionaries
 
-### 📋 Next (see [Roadmap](docs/development/IMPLEMENTATION_ROADMAP.md))
+**Standard Library:**
+-   String methods: `upper()`, `lower()`, `len()`, `contains()`, `split()`, etc.
+-   List methods: `push()`, `pop()`, `len()`, `contains()`, `reverse()`, etc.
+-   Dictionary methods: `keys()`, `values()`, `len()`, `contains()`
+-   Utility functions: `print()`, `input()`, `len()`, `type()`
+-   Advanced functions: `enumerate()`, `zip()`, `sum()`, `min()`, `max()`, `all()`, `any()`, `sorted()`, `reversed()`
 
--   Module system (file-based imports)
--   REPL enhancements (rustyline, multiline)
--   Performance optimizations
+**Infrastructure:**
+-   8-crate workspace with clean architecture
+-   VM-based bytecode execution (>1M instructions/second)
+-   Enhanced REPL with history and multiline support
+-   Comprehensive benchmark suite
+-   651 passing tests with full coverage
 
----
+### Not Implemented (Do Not Use)
 
-**Version**: 0.3.2
-**Last Updated**: 2025-10-28
+**Language Features:**
+-   ❌ Module system / file-based imports
+-   ❌ Type inference
+-   ❌ Assignment operators (`+=`, `-=`, etc.)
+-   ❌ Multiple assignment / destructuring
+-   ❌ Spread operators
+-   ❌ Generic types
+-   ❌ Inheritance
+-   ❌ Result/Option types
+-   ❌ Nested f-strings
+
+**Tooling:**
+-   ❌ LSP server
+-   ❌ Package manager
+-   ❌ Debugger protocol
+-   ❌ VS Code extension
+
+### Quick Reference for AI Assistants
+
+**When a user wants to:**
+-   Add pattern matching → Use `match` with guards (fully working)
+-   Filter/transform lists → Use list comprehensions (fully working)
+-   Format output → Use f-strings (fully working)
+-   Create objects → Use structs with methods (fully working)
+-   Build closures → Capture variables from outer scope (fully working)
+-   Import code → Use `import!("path")` for basic imports only
+
+**Test expectations:**
+-   All 651 tests must pass after changes
+-   Run `cargo test --workspace` to verify
+-   Run `cargo bench --workspace` to check performance regressions
+-   Every new feature needs comprehensive tests
+
+**Performance expectations:**
+-   VM execution: >1M instructions/second
+-   Startup time: <100ms
+-   Memory usage: <10MB for basic programs
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,340 +1,149 @@
 # Lugli Programming Language
 
-[![Tests](https://img.shields.io/badge/tests-385%20passing-brightgreen)](https://github.com/vinicioslugli/lugli-language)
 [![License](https://img.shields.io/badge/license-MIT-blue)](LICENSE.md)
-[![Version](https://img.shields.io/badge/version-0.3.1--dev-orange)](https://github.com/vinicioslugli/lugli-language)
 
-**Lugli** is a high-performance, dynamically-typed programming language that combines Python's simplicity with Rust's modern syntax. Built with a bytecode VM for speed and educational clarity.
+A dynamic language that feels like Python, runs like Rust.
 
-## Quick Start
+**Lugli** is a high-performance scripting language that combines Python's intuitive syntax with Rust's modern language design. Built with a bytecode VM for speed, it's perfect for rapid prototyping, learning language implementation, and scripts that need to be both readable and fast.
 
-### Installation
-
-```bash
-# Clone the repository
-git clone https://github.com/vinicioslugli/lugli-language
-cd lugli-language
-
-# Build the interpreter
-cargo build --release
-
-# Run a program
-cargo run --release -- run examples/basics/01_hello_world.lg
-
-# Start the REPL
-cargo run --release -- repl
-```
-
-### Hello World
+## Quick Look
 
 ```lugli
-let name = "Lugli"
-let version = "0.3.1"
-print!(f"Hello from {name} v{version}!")
+# Pattern matching, list comprehensions, f-strings - all working!
+let numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+let evens = [x * 2 for x in numbers if x % 2 == 0]
+
+match evens.len() {
+    0 => print("No evens found"),
+    n => print(f"Found {n} even numbers: {evens}")
+}
+# Output: Found 5 even numbers: [4, 8, 12, 16, 20]
 ```
 
-## Features
+## What You Can Do
 
-### ✅ Core Language (v0.3.1)
-
--   **Variables**: Mutable by default with `let`
--   **Functions**: `fn name(params) { body }` with closures
--   **Structs**: `struct Name { fields }` with methods
--   **Control Flow**: `if/elif/else`, `while`, `for`, `loop`, `break`, `continue`
--   **Pattern Matching**: `match` expressions with guards ⭐ NEW
--   **List Comprehensions**: `[x * 2 for x in list if x > 0]` ⭐ NEW
--   **Collections**: Lists `[1, 2, 3]` and dictionaries `{"key": "value"}`
--   **F-String Interpolation**: `f"Hello {name}!"`
--   **Negative Indexing**: Python-style `arr[-1]`, `str[-2]`
--   **Safe Arithmetic**: Division-by-zero protection
-
-### 🚀 VM Architecture
-
--   **Bytecode Compilation**: Source → Lexer → Parser → AST → Bytecode → VM
--   **Stack-Based Execution**: >1M instructions/second
--   **Fast Startup**: <100ms cold start
--   **Low Memory**: <10MB for basic programs
--   **Native Functions**: Integrated standard library
-
-### 📚 Standard Library
-
+**Filter and transform data** with list comprehensions:
 ```lugli
-# String methods
-"hello".upper()         # "HELLO"
-"hello".len()          # 5
-"hello".contains("ll") # true
-
-# List methods
-let nums = [1, 2, 3]
-nums.push(4)           # [1, 2, 3, 4]
-nums.pop()             # 4
-nums.len()              # 3
-
-# Dictionary methods
-let data = {"x": 10}
-data.keys()             # ["x"]
-data.values()           # [10]
+let prices = [10, 20, 30, 40, 50]
+let expensive = [p for p in prices if p > 25]
+let with_tax = [p * 1.1 for p in prices]
 ```
 
-## Example Programs
-
+**Pattern match** for cleaner control flow:
 ```lugli
-# Structs with default values
-struct Point {
-    x: 0
-    y: 0
+match status {
+    "success" => handle_success(),
+    "error" => handle_error(),
+    code if code >= 400 => handle_client_error(code),
+    _ => handle_unknown()
+}
+```
 
-    fn distance(self) {
-        return self.x * self.x + self.y * self.y
+**Build objects** with structs and methods:
+```lugli
+struct Counter {
+    value: 0
+
+    fn increment!(self) {
+        self.value = self.value + 1
+    }
+
+    fn get(self) {
+        return self.value
     }
 }
 
-let p = Point { x: 3, y: 4 }
-print(f"Distance: {p.distance()}")  # Distance: 25
-
-# Loops and collections
-let sum = 0
-for n in [1, 2, 3, 4, 5] {
-    sum = sum + n
-}
-print(f"Sum: {sum}")  # Sum: 15
-
-# While with break/continue
-let count = 0
-while count < 10 {
-    count = count + 1
-    if count % 2 == 0 { continue }
-    print(count)  # 1, 3, 5, 7, 9
-}
+let counter = Counter {}
+counter.increment!()
+print(counter.get())  # 1
 ```
 
-See `examples/basics/` for more examples.
+**Format strings** naturally:
+```lugli
+let name = "Lugli"
+let version = "0.4.0"
+print(f"Hello from {name} v{version}!")
+```
 
-## CLI Commands
+**Write closures** that capture context:
+```lugli
+let multiplier = 3
+let triple = fn(x) { return x * multiplier }
+print(triple(5))  # 15
+```
+
+## Get Started
 
 ```bash
-# Run a program
-lugli run <file.lg>
+# Clone and build
+git clone https://github.com/vinicioslugli/lugli-language
+cd lugli-language
+cargo build --release
 
-# Start REPL
-lugli repl
+# Try the REPL
+cargo run --release -- repl
 
-# Check syntax
-lugli check <file.lg>
-
-# Disassemble bytecode (debug)
-lugli disassemble <file.lg>
-
-# Show version
-lugli version
+# Run an example
+cargo run --release -- run examples/basics/01_hello_world.lg
 ```
+
+## Language Features
+
+- **Variables**: `let x = 10`, mutable by default
+- **Functions**: `fn add(a, b) { return a + b }`
+- **Structs**: Define objects with fields and methods
+- **Control Flow**: `if/elif/else`, `while`, `for`, `loop`, `match`
+- **Collections**: Lists `[1, 2, 3]` and dictionaries `{"key": "value"}`
+- **List Comprehensions**: `[x * 2 for x in list if x > 0]`
+- **Pattern Matching**: Match with guards and wildcards
+- **F-Strings**: `f"Hello {name}!"`
+- **Closures**: Functions that capture their environment
+- **Standard Library**: String, list, and dict methods built-in
+
+## CLI Usage
+
+```bash
+lugli run script.lg    # Run a Lugli script
+lugli repl             # Interactive mode with history
+lugli check script.lg  # Check syntax without running
+lugli disassemble      # Show bytecode (debug)
+```
+
+## Examples
+
+Check out the `examples/` directory for working code:
+
+- `examples/basics/` - Core language features
+- `examples/syntax/` - Comprehensive syntax reference
+- `examples/samples/` - Real programs (hangman game, etc.)
 
 ## Architecture
 
-Lugli is organized as a professional Rust workspace with 7 crates:
+Lugli is built as a Rust workspace with 8 specialized crates:
 
-```
-lugli (CLI)
-    ↓
-lugli-vm (Bytecode VM) ← lugli-stdlib (Native Functions)
-    ↓                         ↓
-lugli-parser (AST → Bytecode) ↓
-    ↓                         ↓
-lugli-ast (AST Definitions)   ↓
-    ↓                         ↓
-lugli-lexer (Source → Tokens) ↓
-    ↓                         ↓
-lugli-common (Shared Types) ←─┘
-```
+- **lugli-lexer** - Tokenization
+- **lugli-ast** - Abstract syntax tree
+- **lugli-parser** - Source → AST
+- **lugli-vm** - Bytecode compiler and VM
+- **lugli-stdlib** - Native function library
+- **lugli-common** - Shared types
+- **lugli** - CLI and REPL
+- **lugli-benchmarks** - Performance testing
 
-**Key Features**:
+The execution pipeline: Source → Lexer → Parser → AST → Bytecode → VM
 
--   Zero circular dependencies
--   Clean separation of concerns
--   Comprehensive test coverage (385 tests)
--   Professional error handling with source spans
+## Learn More
 
-## Development
-
-### Building
-
-```bash
-# Build all crates
-cargo build --workspace
-
-# Run tests
-cargo test --workspace
-
-# Run specific crate tests
-cargo test -p lugli-vm
-
-# Format code
-cargo fmt --workspace
-
-# Lint
-cargo clippy --workspace
-```
-
-### Project Structure
-
-```
-crates/
-├── lugli/          # CLI tool and REPL
-├── lugli-vm/       # Bytecode virtual machine
-├── lugli-stdlib/   # Standard library (native functions)
-├── lugli-parser/   # Parser (tokens → AST)
-├── lugli-ast/      # AST definitions
-├── lugli-lexer/    # Lexer (source → tokens)
-└── lugli-common/   # Shared types (Value, Error, Span)
-
-examples/
-├── basics/         # Working examples (v0.3.0)
-└── future/         # Planned features (v0.4.0+)
-
-docs/               # Documentation (coming soon)
-```
-
-## Current Status
-
-**Version**: 0.3.1-dev (Modern Features)
-
-### What Works
-
--   ✅ Complete VM-based execution pipeline
--   ✅ Core language features (variables, functions, structs, control flow)
--   ✅ **Pattern matching** with literal/identifier/wildcard patterns and guards
--   ✅ **List comprehensions** with filters
--   ✅ **Closures** with upvalue capture
--   ✅ Collections (lists, dicts) with methods
--   ✅ F-string interpolation
--   ✅ Negative indexing
--   ✅ Safe arithmetic
--   ✅ 385 tests passing (100%)
-
-### Known Limitations
-
--   No nested f-strings (planned v0.4.0)
--   No module system (planned v0.4.0)
--   No type inference (planned v0.5.0)
--   No LSP server (planned v0.5.0)
--   Limited REPL (no multiline support)
-
-See `CLAUDE.md` for complete roadmap and implementation details.
-
-## Roadmap
-
-### v0.3.1 (Current) - Modern Features ✅
-
--   ✅ List comprehensions with filters
--   ✅ Closures with upvalue capture
--   ✅ Pattern matching with guards
--   ✅ Enhanced stdlib (zip, all, any, sum, min, max, sorted, reversed)
-
-### v0.4.0 (4-6 Weeks) - Module System & Polish
-
--   🔮 Module system with imports/exports
--   🔮 Enhanced error messages with stack traces
--   🔮 F-string runtime improvements
--   🔮 REPL multiline support
--   🔮 Assignment operators (`+=`, `-=`, etc.)
--   🔮 Benchmark suite
-
-### v0.5.0 (2-3 Months) - Developer Experience
-
--   🔮 Type inference engine
--   🔮 LSP server (autocomplete, diagnostics)
--   🔮 VS Code extension
--   🔮 Debugger protocol
--   🔮 Package manager design
-
-### v1.0.0 (6-12 Months) - Production Ready
-
--   🔮 Comprehensive standard library (50+ functions)
--   🔮 Package registry
--   🔮 Performance optimizations (JIT, constant folding)
--   🔮 Security audit
--   🔮 Production case studies
-
-## Contributing
-
-Contributions welcome! This is an educational project demonstrating language implementation.
-
-**Areas for Contribution**:
-
--   Feature implementation (see roadmap)
--   Bug fixes
--   Documentation
--   Example programs
--   Standard library functions
--   Performance optimizations
-
-See `CLAUDE.md` for architecture details and development guidelines.
-
-## Testing
-
-```bash
-# Run all tests
-cargo test --workspace
-
-# Run with output
-cargo test --workspace -- --nocapture
-
-# Run specific test
-cargo test -p lugli-vm test_vm_arithmetic
-
-# Test all examples
-for file in examples/basics/*.lg; do
-    cargo run -- run "$file"
-done
-```
-
-**Test Statistics**:
-
--   Total: 385 tests
--   Passing: 385 (100%)
--   Ignored: 5 (advanced features in development)
--   Coverage: Comprehensive across all crates
-
-## Performance
-
-**Benchmarks** (target specifications):
-
--   **Startup**: <100ms ✅
--   **Execution**: >1M instructions/second ✅
--   **Memory**: <10MB for basic programs ✅
--   **Binary Size**: ~1.3MB (release build with LTO) ✅
-
-## Documentation
-
--   **CLAUDE.md**: Architecture guide for AI assistants and developers
--   **examples/basics/README.md**: Guide to working examples
--   **examples/future/README.md**: Planned features roadmap
-
-**Coming Soon**:
-
--   Language specification
--   API reference
--   Tutorial series
--   Design decisions document
+- **CLAUDE.md** - Architecture details and internals
+- **examples/** - Working code samples
+- **GitHub Issues** - Questions and discussions welcome
 
 ## License
 
-This project is licensed under the MIT License - see [LICENSE.md](LICENSE.md) for details.
+MIT License - see [LICENSE.md](LICENSE.md)
 
-**Note**: Educational project for learning language implementation.
-
-## Credits
-
-**Author**: Vinicios Lugli
-**Inspiration**: Python (simplicity) + Rust (performance)
-**Purpose**: Learning compiler/VM implementation
-
-## Resources
-
--   **Repository**: https://github.com/vinicioslugli/lugli-language
--   **Issues**: https://github.com/vinicioslugli/lugli-language/issues
--   **Discussions**: https://github.com/vinicioslugli/lugli-language/discussions
+Built with Rust by [Vinicios Lugli](https://github.com/vinicioslugli)
 
 ---
 
-_Built with ❤️ in Rust_
+*An educational project demonstrating language implementation with Python's simplicity and Rust's performance*


### PR DESCRIPTION
README.md changes (340 → 149 lines):
- User-focused content with immediate code examples
- Removed development noise (test counts, roadmaps, benchmarks)
- Lead with compelling features and practical use cases
- Simplified from mixed audience to pure user documentation
- Inspired by Rune/Boa README style

CLAUDE.md changes (856 → 816 lines):
- Updated version to 0.4.0 with 651 passing tests
- Added lugli-benchmarks crate to architecture
- Removed all roadmap/planning sections
- Added Feature Status section with clear implemented/not-implemented lists
- Added Quick Reference for AI Assistants
- Enhanced REPL documentation (rustyline integration)
- Focused on current capabilities vs future plans

All code examples verified working. All 651 tests passing.